### PR TITLE
Ability to rotate shapes clockwise

### DIFF
--- a/engine.c
+++ b/engine.c
@@ -79,7 +79,7 @@ static void real_rotate (shape_t *shape,bool clockwise)
 }
 
 /* Rotate shapes the way tetris likes it (= not mathematically correct) */
-static void fake_rotate (shape_t *shape)
+static void fake_rotate (shape_t *shape,bool clockwise)
 {
    switch (shape->type)
 	 {
@@ -92,10 +92,10 @@ static void fake_rotate (shape_t *shape)
 		if (shape->flipped) real_rotate (shape,FALSE); else real_rotate (shape,TRUE);
 		shape->flipped = !shape->flipped;
 		break;
-	  case 2:	/* Rotate these three anti-clockwise */
+	  case 2:	/* Rotate these three according to supplied direction */
 	  case 4:
 	  case 5:
-		real_rotate (shape,FALSE);
+		real_rotate (shape,clockwise);
 		break;
 	  case 3:	/* This one is not rotated at all */
 		break;
@@ -177,7 +177,7 @@ static bool shape_right (engine_t *engine)
 }
 
 /* Rotate the shape if possible */
-static bool shape_rotate (engine_t *engine)
+static bool shape_rotate (engine_t *engine,bool clockwise)
 {
    board_t *board = &engine->board;
    shape_t *shape = &engine->shapes[engine->curshape];
@@ -186,7 +186,7 @@ static bool shape_rotate (engine_t *engine)
    eraseshape (*board,shape,engine->curx,engine->cury);
    if (engine->shadow) eraseshape (*board,shape,engine->curx_shadow,engine->cury_shadow);
    memcpy (&test,shape,sizeof (shape_t));
-   fake_rotate (&test);
+   fake_rotate (&test,clockwise);
    if (allowed (*board,&test,engine->curx,engine->cury))
 	 {
 		memcpy (shape,&test,sizeof (shape_t));
@@ -339,9 +339,13 @@ void engine_move (engine_t *engine,action_t action)
 	  case ACTION_LEFT:
         if (shape_left (engine)) engine->status.moves++;
 		break;
-		/* rotate shape if possible */
-	  case ACTION_ROTATE:
-		if (shape_rotate (engine)) engine->status.rotations++;
+		/* rotate shape clockwise if possible */
+	  case ACTION_ROTATE_CLOCKWISE:
+		if (shape_rotate (engine, true)) engine->status.rotations++;
+		break;
+		/* rotate shape counterclockwise if possible */
+	  case ACTION_ROTATE_COUNTERCLOCKWISE:
+		if (shape_rotate (engine, false)) engine->status.rotations++;
 		break;
 		/* move shape to the right if possible */
 	  case ACTION_RIGHT:

--- a/engine.h
+++ b/engine.h
@@ -91,7 +91,7 @@ typedef struct engine_struct
    void (*score_function)(struct engine_struct *);	/* score function */
 } engine_t;
 
-typedef enum { ACTION_LEFT, ACTION_ROTATE, ACTION_RIGHT, ACTION_DROP, ACTION_DOWN } action_t;
+typedef enum { ACTION_LEFT, ACTION_ROTATE_CLOCKWISE, ACTION_ROTATE_COUNTERCLOCKWISE, ACTION_RIGHT, ACTION_DROP, ACTION_DOWN } action_t;
 
 /*
  * Global variables

--- a/tint.c
+++ b/tint.c
@@ -166,13 +166,14 @@ static void drawbackground ()
    out_gotoxy (1,YTOP + 9);   out_printf ("p: Pause");
    out_gotoxy (1,YTOP + 10);  out_printf ("j: Left");
    out_gotoxy (1,YTOP + 11);  out_printf ("l: Right");
-   out_gotoxy (1,YTOP + 12);  out_printf ("k: Rotate");
-   out_gotoxy (1,YTOP + 13);  out_printf ("s: Draw next");
-   out_gotoxy (1,YTOP + 14);  out_printf ("d: Toggle lines");
-   out_gotoxy (1,YTOP + 15);  out_printf ("a: Speed up");
-   out_gotoxy (1,YTOP + 16);  out_printf ("q: Quit");
-   out_gotoxy (2,YTOP + 17);  out_printf ("SPACE: Drop");
-   out_gotoxy (3,YTOP + 19);  out_printf ("Next:");
+   out_gotoxy (1,YTOP + 12);  out_printf ("K: Rotate (clockwise)");
+   out_gotoxy (1,YTOP + 13);  out_printf ("k: Rotate (counterclockwise)");
+   out_gotoxy (1,YTOP + 14);  out_printf ("s: Draw next");
+   out_gotoxy (1,YTOP + 15);  out_printf ("d: Toggle lines");
+   out_gotoxy (1,YTOP + 16);  out_printf ("a: Speed up");
+   out_gotoxy (1,YTOP + 17);  out_printf ("q: Quit");
+   out_gotoxy (2,YTOP + 18);  out_printf ("SPACE: Drop");
+   out_gotoxy (3,YTOP + 20);  out_printf ("Next:");
 }
 
 static int getsum ()

--- a/tint.c
+++ b/tint.c
@@ -630,7 +630,10 @@ int main (int argc,char *argv[])
 				case 'k':
 				case KEY_UP:
 				case '\n':
-				  engine_move (&engine,ACTION_ROTATE);
+				  engine_move (&engine,ACTION_ROTATE_COUNTERCLOCKWISE);
+				  break;
+				case 'K':
+				  engine_move (&engine,ACTION_ROTATE_CLOCKWISE);
 				  break;
 				case 'l':
 				case KEY_RIGHT:


### PR DESCRIPTION
Add option to rotate shape clockwise as well as counter-clockwise.

The Game Boy version of Tetris (and presumably other early versions) allowed shapes to be rotated in either direction by choosing whether to press A or B.  This PR adds clockwise rotation capability to tint (via "K" key).

Revised help text shows new capability as follows:
```
    H E L P                  
                             
 p: Pause                    
 j: Left                     
 l: Right                    
 K: Rotate (clockwise)       
 k: Rotate (counterclockwise)
 s: Draw next                
 d: Toggle lines             
 a: Speed up                 
 q: Quit                     
  SPACE: Drop                
```