### PR TITLE
Address vwprintw deprecation warning on build

### DIFF
--- a/io.c
+++ b/io.c
@@ -142,7 +142,7 @@ void out_printf (char *format, ...)
 {
    va_list ap;
    va_start (ap,format);
-   vwprintw (stdscr,format,ap);
+   vw_printw (stdscr,format,ap);
    va_end (ap);
 }
 


### PR DESCRIPTION
See https://linux.die.net/man/3/vwprintw - vwprintw is replaced with vw_printw.